### PR TITLE
chore: Support to CommonJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
-    "import": "./dist/index.js"
+    "import": "./dist/index.js",
+    "require": "./dist/index.js"
   },
   "bin": {
     "imagefx": "./dist/cli.js"


### PR DESCRIPTION
This PR adds support for CommonJS consumers by including a "require" field in the exports section of package.json. This allows projects using CommonJS (require()) to import the package without encountering ERR_PACKAGE_PATH_NOT_EXPORTED errors.

Only package.json was updated to improve compatibility.

