### PR TITLE
bugfix/images-overriding-issue

### DIFF
--- a/src/Image.ts
+++ b/src/Image.ts
@@ -1,7 +1,7 @@
 import { join } from "path";
 import { AspectRatio, Model } from "./Constants.js";
 import { ImageArg } from "./Types.js";
-import { existsSync, mkdirSync, writeFileSync, } from "fs";
+import { existsSync, mkdirSync, writeFileSync } from "fs";
 
 export class ImageError extends Error {
     constructor(message: string) {
@@ -38,6 +38,11 @@ export class Image {
     public readonly prompt: string;
 
     /**
+     * Index of generated image
+     */
+    public readonly idx?: number;
+
+    /**
      * Aspect ratio of this image
      */
     public readonly aspectRatio: AspectRatio;
@@ -62,7 +67,7 @@ export class Image {
      */
     private readonly fingerprintId: string; // fingerprintLogRecordId
 
-    constructor(args: ImageArg) {
+    constructor(args: ImageArg, index?: number) {
         if (!args.encodedImage?.trim()) {
             throw new ImageError("Encoded image data is required");
         }
@@ -76,6 +81,7 @@ export class Image {
         this.encodedImage = args.encodedImage;
         this.mediaId = args.mediaGenerationId;
         this.fingerprintId = args.fingerprintLogRecordId;
+        this.idx = index || 0;
     }
 
     /**
@@ -85,10 +91,10 @@ export class Image {
      * @param filePath Directory for the image to be saved
      */
     public save(filePath = ".") {
-        const imageName = `image-${Date.now()}.png`;
+        const imageName = `image-${this.idx}-${Date.now()}.png`;
 
         if (!existsSync(filePath)) {
-            console.log("[*] Creating destination dir:", filePath)
+            console.log("[*] Creating destination dir:", filePath);
 
             try {
                 mkdirSync(filePath, { recursive: true });

--- a/src/ImageFX.ts
+++ b/src/ImageFX.ts
@@ -51,7 +51,7 @@ export class ImageFX {
         await this.account.refreshSession()
 
         const generatedImages = await this.fetchImages(prompt, retries);
-        return generatedImages.map((data: ImageArg) => new Image(data));
+        return generatedImages.map((data: ImageArg, idx) => new Image(data, idx));
     }
 
     /**


### PR DESCRIPTION
Hello, 
I noticed that sometimes we could get fewer images than expected, and it's because time to time we could have them overridden due to having the same timestamp. 

<img width="720" height="139" alt="Screenshot 2025-11-28 at 11 08 07" src="https://github.com/user-attachments/assets/3832a353-1d19-44ba-995f-c346d4c580b4" />

So, I've introduced the usage index to ensure our image file names are always unique. 

TODO: Might some tests needs to be updated
anyway, thank you for the tool! 
